### PR TITLE
Add support for unix domain socket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
         memcached -d -p 11211
         memcached -d -p 11212
         memcached -d -p 11213 --enable-ssl -o ssl_chain_cert=./tests/acceptance/data/localhost.crt,ssl_key=./tests/acceptance/data/localhost.key
+        memcached -s /tmp/emcache.sock -a 777
     - name: Docker dependencies
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,11 @@ services:
       - ./:/app
     ports:
       - "11213:11213"
+  memcached_uds:
+    image: memcached
+    command: ['-s', '/sockets/emcache.sock', '-a', '777']
+    volumes:
+      - ./:/app
+      - type: bind
+        source: /tmp/
+        target: /sockets/

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -18,6 +18,17 @@ For example
         ]
     )
 
+Or, in the case of a memcached server listening on a unix domain socket
+
+.. code-block:: python
+
+   client = await emcache.create_client(
+       [
+           emcache.MemcachedHostAddress('/tmp/memcached.sock', 0)
+       ]
+   )
+
+
 The previous example would return a :class:`emcache.Client` object instance that will perform the operations to two different Nodes, depending on the outcome of the hashing algorithm.
 Take a look to the advanced topics section and specifically to the Hashing section for understanding how operations are being routed to the different nodes.
 

--- a/emcache/protocol.py
+++ b/emcache/protocol.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import socket
 from typing import List, Optional, Tuple, Union
 

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -16,8 +16,22 @@ async def memcached_address_2():
 
 
 @pytest.fixture
+async def memcached_unix_socket():
+    return MemcachedHostAddress("/tmp/emcache.sock", 0)
+
+
+@pytest.fixture
 async def client(event_loop, memcached_address_1, memcached_address_2):
     client = await create_client([memcached_address_1, memcached_address_2], timeout=2.0,)
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+@pytest.fixture
+async def client_unix_socket(event_loop, memcached_unix_socket):
+    client = await create_client([memcached_unix_socket], timeout=2.0,)
     try:
         yield client
     finally:

--- a/tests/acceptance/test_cluster_managment.py
+++ b/tests/acceptance/test_cluster_managment.py
@@ -9,6 +9,9 @@ class TestClusterManagment:
     async def test_nodes(self, client, memcached_address_1, memcached_address_2):
         assert client.cluster_managment().nodes() == [memcached_address_1, memcached_address_2]
 
+    async def test_nodes_unix_socket(self, client_unix_socket, memcached_unix_socket):
+        assert client_unix_socket.cluster_managment().nodes() == [memcached_unix_socket]
+
     async def test_healthy_nodes(self, client, memcached_address_1, memcached_address_2):
         assert client.cluster_managment().healthy_nodes() == [memcached_address_1, memcached_address_2]
 

--- a/tests/acceptance/test_unix_socket.py
+++ b/tests/acceptance/test_unix_socket.py
@@ -1,0 +1,18 @@
+import pytest
+
+from emcache import MemcachedHostAddress, create_client
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+async def memcached_unix_socket():
+    return MemcachedHostAddress("/tmp/emcache.sock", 0)
+
+
+class TestUnixSocket:
+    async def test_create_client(self, memcached_unix_socket):
+        client = await create_client([memcached_unix_socket], timeout=1.0)
+        await client.set(b"key", b"1")
+        assert (await client.get(b"key")).value == b"1"
+        await client.close()

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -24,6 +24,11 @@ class TestMemcachedHostAddress:
         assert memcached_node.address == "localhost"
         assert memcached_node.port == 11211
 
+    def test_attributes_uds(self):
+        memcached_node = MemcachedHostAddress("/tmp/emcache.sock", 0)
+        assert memcached_node.address == "/tmp/emcache.sock"
+        assert memcached_node.port == 0
+
 
 class TestNode:
     async def test_properties(self, connection_pool, memcached_host_address):


### PR DESCRIPTION
# Description

Adds support for connecting to memcached instances listening on unix domain sockets instead of tcp host/port pairs.

## Requested feedback
I went with the least intrusive change to add this support, however reusing `MemcachedHostAddress` for a unix socket is definitely hacky. Adding a new `MemcachedHostPath` dataclass would be cleaner I think but would require refactoring the `create_protocol` function - which I'm happy to do if you think that's okay.

