### PR TITLE
Support Apple Silicon Build to Resolve #67

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,13 +3,66 @@ on:
   push:
     tags:
       - v*
+
 jobs:
-  build:
+  # Use Any Python version, cibuildwheel downloads multiple python version to create each build environment.
+  # We can only use x86-64 macOS, so we can test on x86-64. But murmur3 is now universal2 binary. So It'll be works for arm64 too.
+  build_macos:
+    outputs:
+      version: ${{ steps.get_version.outputs.VERSION }}
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - name: Generate macos-wheel
+      run: |
+        cd vendor/murmur3
+        make static_macos
+        cd -
+        python -m pip install --upgrade pip
+        pip install wheel cibuildwheel==2.8.0
+        make compile
+        python -m cibuildwheel --platform macos --output-dir dist/
+      env: 
+        CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+    - name: Mac acceptance test dependencies
+      run: |
+        brew install memcached
+        memcached -d -p 11211
+        memcached -d -p 11212
+        memcached -d -p 11213 --enable-ssl -o ssl_chain_cert=./tests/acceptance/data/localhost.crt,ssl_key=./tests/acceptance/data/localhost.key
+    - name: Test generated wheel (Universal2 to x86-64 Only)
+      run: |
+        mkdir test_wheel
+        cp dist/*.whl test_wheel
+        cd test_wheel
+        pip install virtualenv
+        python -m virtualenv env
+        source env/bin/activate
+        rm -f ../.install-cython
+        make -C ../vendor/murmur3 clean static_macos
+        make -C .. install-dev
+        pip install emcache-*-cp310-cp310-macosx_10_9_universal2.whl --upgrade
+        make -C .. test
+    - name: Get the version
+      id: get_version
+      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ steps.get_version.outputs.VERSION }}
+        path: test_wheel/emcache-*.whl
+
+  build_linux:
     outputs:
       version: ${{ steps.get_version.outputs.VERSION }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -20,33 +73,14 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Generate macos-wheel
-      if: ${{ matrix.os == 'macos-latest' }}
-      run: |
-        cd vendor/murmur3
-        make static
-        cd -
-        python -m pip install --upgrade pip
-        pip install wheel
-        make compile
-        python setup.py bdist_wheel
     - name: Generate manylinux1-wheel
-      if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         mkdir /tmp/emcache
         cp -r . /tmp/emcache
         docker run -v /tmp/emcache:/io -e "PYTHON_VERSION=${{matrix.python-version}}" quay.io/pypa/manylinux2010_x86_64 /io/bin/build_manylinux1_wheel.sh
         mkdir dist
         cp /tmp/emcache/dist/emcache-*.whl dist/
-    - name: Mac acceptance test dependencies
-      if: ${{ matrix.os == 'macos-latest' }}
-      run: |
-        brew install memcached
-        memcached -d -p 11211
-        memcached -d -p 11212
-        memcached -d -p 11213 --enable-ssl -o ssl_chain_cert=./tests/acceptance/data/localhost.crt,ssl_key=./tests/acceptance/data/localhost.key
     - name: Linux acceptance test dependencies
-      if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         docker-compose up -d
     - name: Test generated wheel
@@ -59,7 +93,6 @@ jobs:
         source env/bin/activate
         rm -f ../.install-cython
         make -C ../vendor/murmur3 static
-        make -C .. install-dev
         pip install emcache-*.whl --upgrade
         make -C .. test
     - name: Get the version
@@ -69,8 +102,9 @@ jobs:
       with:
         name: ${{ steps.get_version.outputs.VERSION }}
         path: test_wheel/emcache-*.whl
+
   upload:
-    needs: build
+    needs: [build_macos, build_linux]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[options]
+python_requires = >=3.7
+
 [flake8]
 max-line-length = 120
 exclude = .eggs,env


### PR DESCRIPTION
This PR resolves #67. Kudos for maintainers, contributors of emcache. I appreciate it.

### What Changed?

1. I separated macOS Build and Linux Build.
2. On macOS, emcache uses `cibuildwheel` for create multi-architecture wheels.
3. I applied new murmur3's commit. ([PR](https://github.com/pfreixes/murmur3/pull/1)) So I can build emcache with multiple targets!
4. But GitHub Actions only works for macOS x86_64, so we can test universal2 wheel on x86_64 only. It's important limitation.

### Is really works for `arm64`?

Yes. I already tested in my local branch. It's output for test with `arm64` wheel binary. It's same output with `x86_64`'s result.
And I really tested with [application](https://github.com/item4/yui) which use emcache in M1 Pro.

```
❯ pip install emcache-0.6.1-cp310-cp310-macosx_11_0_arm64.whl --upgrade
Processing ./emcache-0.6.1-cp310-cp310-macosx_11_0_arm64.whl
Installing collected packages: emcache
  Attempting uninstall: emcache
    Found existing installation: emcache 0.6.1
    Uninstalling emcache-0.6.1:
      Successfully uninstalled emcache-0.6.1
Successfully installed emcache-0.6.1

[notice] A new release of pip available: 22.1.2 -> 22.2.1
[notice] To update, run: pip install --upgrade pip

emcache/test on  apple-silicon [$!+?] via 🐍 v3.10.5 (venv) on ☁️  (ap-northeast-2)
❯ make -C .. test
pytest -sv tests
============================================================================= test session starts =============================================================================
platform darwin -- Python 3.10.5, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /Users/Realignist/Workspace/emcache/venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/Realignist/Workspace/emcache, configfile: setup.cfg
plugins: mock-3.1.0, cov-2.8.1, asyncio-0.11.0
collected 267 items

tests/acceptance/test_autobatching.py::TestAutobatching::test_get_multiple_keys[1] PASSED
tests/acceptance/test_autobatching.py::TestAutobatching::test_get_multiple_keys[32] PASSED
tests/acceptance/test_autobatching.py::TestAutobatching::test_get_multiple_keys[64] PASSED
...  TRUNCATED ...
tests/unit/_cython/protocol/ascii/test_ascii_one_line_parser.py::TestAsciiOneLineParser::test_feed_data_with_finish_event_set[lines3-foo] PASSED

============================================================================== warnings summary ===============================================================================
venv/lib/python3.10/site-packages/asynctest/mock.py:434
  /Users/Realignist/Workspace/emcache/venv/lib/python3.10/site-packages/asynctest/mock.py:434: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def wait(self, skip=0):

... TRUNCATED ...

tests/unit/test_connection_pool.py::TestConnectionPool::test_create_and_update_connection_timestamp
  /opt/homebrew/Cellar/python@3.10/3.10.5/Frameworks/Python.framework/Versions/3.10/lib/python3.10/inspect.py:3083: RuntimeWarning: coroutine 'ConnectionPool._create_new_connection' was never awaited
    parameters_ex = (param,)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=============================================================== 255 passed, 12 skipped, 1465 warnings in 6.53s ================================================================
Task exception was never retrieved
future: <Task finished name='Task-1208' coro=<ConnectionPool._create_new_connection() done, defined at /Users/Realignist/Workspace/emcache/venv/lib/python3.10/site-packages/emcache/connection_pool.py:214> exception=RuntimeError('coroutine raised StopIteration')>
Traceback (most recent call last):
  File "/Users/Realignist/Workspace/emcache/venv/lib/python3.10/site-packages/emcache/connection_pool.py", line 225, in _create_new_connection
    connection = await create_protocol(
  File "/opt/homebrew/Cellar/python@3.10/3.10.5/Frameworks/Python.framework/Versions/3.10/lib/python3.10/unittest/mock.py", line 1104, in __call__
    return self._mock_call(*args, **kwargs)
  File "/Users/Realignist/Workspace/emcache/venv/lib/python3.10/site-packages/asynctest/mock.py", line 586, in _mock_call
    result = super()._mock_call(*args, **kwargs)
  File "/opt/homebrew/Cellar/python@3.10/3.10.5/Frameworks/Python.framework/Versions/3.10/lib/python3.10/unittest/mock.py", line 1108, in _mock_call
    return self._execute_mock_call(*args, **kwargs)
  File "/opt/homebrew/Cellar/python@3.10/3.10.5/Frameworks/Python.framework/Versions/3.10/lib/python3.10/unittest/mock.py", line 1165, in _execute_mock_call
    result = next(effect)
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/Realignist/Workspace/emcache/venv/lib/python3.10/site-packages/emcache/connection_pool.py", line 281, in _create_new_connection
    await self._create_new_connection(backoff=backoff, retries=retries)
  File "/Users/Realignist/Workspace/emcache/venv/lib/python3.10/site-packages/emcache/connection_pool.py", line 281, in _create_new_connection
    await self._create_new_connection(backoff=backoff, retries=retries)
  File "/Users/Realignist/Workspace/emcache/venv/lib/python3.10/site-packages/emcache/connection_pool.py", line 281, in _create_new_connection
    await self._create_new_connection(backoff=backoff, retries=retries)
  [Previous line repeated 3 more times]
RuntimeError: coroutine raised StopIteration

emcache/test on  apple-silicon [$!+?] via 🐍 v3.10.5 (venv) on ☁️  (ap-northeast-2) took 7s
❯ uname -a
Darwin [CENSORED] 21.6.0 Darwin Kernel Version 21.6.0: Sat Jun 18 17:07:22 PDT 2022; root:xnu-8020.140.41~1/RELEASE_ARM64_T6000 arm64
```

```
yui on  feature/openweather [$!?] is 📦 v0.0.0 via 🐍 v3.10.5 (yui-hdYLmfP4-py3.10) on ☁️  (ap-northeast-2) 
❯ YUI_TEST_DATABASE_URL='CENSORED' GOOGLE_API_KEY='CENSORED' OPENWEATHER_API_KEY="CENSORED" pytest -v tests/apps/weather
================================================================================================================================== test session starts ===================================================================================================================================
platform darwin -- Python 3.10.5, pytest-7.1.2, pluggy-1.0.0 -- /Users/Realignist/Library/Caches/pypoetry/virtualenvs/yui-hdYLmfP4-py3.10/bin/python
cachedir: .pytest_cache
rootdir: /Users/Realignist/Workspace/yui, configfile: pyproject.toml
plugins: asyncio-0.18.3, time-machine-2.7.1, cov-3.0.0
asyncio: mode=auto
collected 10 items                                                                                                                                                                                                                                                                       

tests/apps/weather/weather_test.py::test_clothes_by_temperature PASSED                                                                                                                                                                                                             [ 10%]
tests/apps/weather/weather_test.py::test_get_geometric_info_by_address PASSED                                                                                                                                                                                                      [ 20%]
tests/apps/weather/weather_test.py::test_get_weather_wrong_geometric_info PASSED                                                                                                                                                                                                   [ 30%]
tests/apps/weather/weather_test.py::test_get_weather_with_wrong_openweather_coordination PASSED                                                                                                                                                                                    [ 40%]
tests/apps/weather/weather_test.py::test_get_air_pollution_with_wrong_coordination PASSED                                                                                                                                                                                          [ 50%]
tests/apps/weather/weather_test.py::test_get_aqi_description PASSED                                                                                                                                                                                                                [ 60%]
tests/apps/weather/weather_test.py::test_degree_to_direction PASSED                                                                                                                                                                                                                [ 70%]
tests/apps/weather/weather_test.py::test_weather PASSED                                                                                                                                                                                                                            [ 80%]
tests/apps/weather/weather_test.py::test_weather_geocoding_error PASSED                                                                                                                                                                                                            [ 90%]
tests/apps/weather/weather_test.py::test_weather_openweather_error PASSED                                                                                                                                                                                                          [100%]

=================================================================================================================================== 10 passed in 1.56s ===================================================================================================================================
```
