### PR TITLE
[Release CI] Fix CI for Linux Wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,7 @@ jobs:
         source env/bin/activate
         rm -f ../.install-cython
         make -C ../vendor/murmur3 static
+        make -C .. install-dev
         pip install emcache-*.whl --upgrade
         make -C .. test
     - name: Get the version


### PR DESCRIPTION
Sorry for Late. I checked my PR and previous GitHub Actions definition and I found my mistake.
My PR removed to install dev dependency before checking wheels. So I fixed this, and It works well in my draft branch.

![image](https://user-images.githubusercontent.com/1115741/184468522-f238f2a8-0518-43e9-91cb-ac8c562856d6.png)
