### PR TITLE
Fix PyPI Release Pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v2
       with:
-        name: ${{ needs.build.outputs.version }}
+        # build_macos and build_linux will uses same version,
+        # so we can download it at once
+        name: ${{ needs.build_linux.outputs.version }}
         path: wheelhouse/
     - name: Display content
       run: ls -R


### PR DESCRIPTION
First, I have to apologize to emcache community that I was too irresponsible and I'm too late to handle this issue.

To fix release pipeline issue, I have to check difference of previous versions and current version. (Especially GitHub Actions.) Previous Version’s downloaded artifacts are in `./wheelhouse` directory, but Current version’s artifacts are in `./wheelhouse/v{version}`. So I’m trying to fix artifacts directory.

I don't have permission to check this permission to release this. I think we have to review this PR before merge it.

For Interest, [Here](https://github.com/Hazealign/emcache/actions/runs/3354038250/jobs/5557315108)'s Action Log for `v0.6.0`, [Here](https://github.com/Hazealign/emcache/actions/runs/3353986392/jobs/5557274958) is the Previous Actions Log for `v0.6.2`. [Here](https://github.com/Hazealign/emcache/actions/runs/3354719977/jobs/5558514096)'s the patched Actions Log. You have to see `upload` job's `Display content` task.