### PR TITLE
expose connection pool metrics through ClusterManagment

### DIFF
--- a/emcache/base.py
+++ b/emcache/base.py
@@ -1,7 +1,8 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
 from dataclasses import dataclass
-from typing import Dict, Optional, Sequence
+from typing import Dict, Mapping, Optional, Sequence
 
+from .connection_pool import ConnectionPoolMetrics
 from .node import MemcachedHostAddress
 
 
@@ -309,3 +310,7 @@ class ClusterManagment(metaclass=ABCMeta):
     @abstractmethod
     def unhealthy_nodes(self) -> Sequence[MemcachedHostAddress]:
         """Return the nodes that are considered unhealthy."""
+    
+    @abstractmethod
+    def connection_pool_metrics(self) -> Mapping[MemcachedHostAddress, ConnectionPoolMetrics]:
+        """Return the metrics for the connection pools."""

--- a/emcache/base.py
+++ b/emcache/base.py
@@ -310,7 +310,7 @@ class ClusterManagment(metaclass=ABCMeta):
     @abstractmethod
     def unhealthy_nodes(self) -> Sequence[MemcachedHostAddress]:
         """Return the nodes that are considered unhealthy."""
-    
+
     @abstractmethod
     def connection_pool_metrics(self) -> Mapping[MemcachedHostAddress, ConnectionPoolMetrics]:
         """Return the metrics for the connection pools."""


### PR DESCRIPTION
The metrics in the connection pool are useful for the application. In my particular case integrating 'total connections' with kubernetes readiness check so that my application only starts accepting requests when the cache client has reached it's minimum open connections count across all the nodes in a cluster.