### PR TITLE
build-manylinux-aarch64-wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,21 +107,25 @@ jobs:
   build_linux_aarch64:
     outputs:
       version: ${{ steps.get_version.outputs.VERSION }}
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        os: [macos-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Set up Python
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: "3.11"
+        python-version: ${{ matrix.python-version }}
     - name: Generate manylinux2014_aarch64-wheel
       run: |
         brew install docker
         brew install colima
         colima start
-        docker run --platform linux/arm64 -v `pwd`:/io -e "PYTHON_VERSION=3.11" quay.io/pypa/manylinux2014_aarch64 /io/bin/build_manylinux1_wheel.sh
+        docker run --platform linux/arm64 -v `pwd`:/io -e "PYTHON_VERSION=${{ matrix.python-version }}" quay.io/pypa/manylinux2014_aarch64 /io/bin/build_manylinux1_wheel.sh
         mkdir test_wheel
         mv dist/emcache-*.whl test_wheel
     - name: Run unit tests using the wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,9 +103,40 @@ jobs:
       with:
         name: ${{ steps.get_version.outputs.VERSION }}
         path: test_wheel/emcache-*.whl
+    
+  build_linux_aarch64:
+    outputs:
+      version: ${{ steps.get_version.outputs.VERSION }}
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.11"
+    - name: Generate manylinux2014_aarch64-wheel
+      run: |
+        brew install docker
+        brew install colima
+        colima start
+        docker run --platform linux/arm64 -v `pwd`:/io -e "PYTHON_VERSION=3.11" quay.io/pypa/manylinux2014_aarch64 /io/bin/build_manylinux1_wheel.sh
+        mkdir test_wheel
+        mv dist/emcache-*.whl test_wheel
+    - name: Run unit tests using the wheel
+      run: |
+        docker run --platform linux/arm64 --entrypoint bash -v `pwd`:/io python:3.11-bookworm /io/bin/test_aarch_wheel.sh
+    - name: Get the version
+      id: get_version
+      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: aarch64-${{ steps.get_version.outputs.VERSION }}
+        path: test_wheel/emcache-*.whl
 
   upload:
-    needs: [build_macos, build_linux]
+    needs: [build_macos, build_linux, build_linux_aarch64]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -114,6 +145,10 @@ jobs:
         # build_macos and build_linux will uses same version,
         # so we can download it at once
         name: ${{ needs.build_linux.outputs.version }}
+        path: wheelhouse/
+    - uses: actions/download-artifact@v2
+      with:
+        name: aarch64-${{ needs.build_linux_aarch64.outputs.version }}
         path: wheelhouse/
     - name: Display content
       run: ls -R

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,12 +125,12 @@ jobs:
         brew install docker
         brew install colima
         colima start
-        docker run --platform linux/arm64 -v `pwd`:/io -e "PYTHON_VERSION=${{ matrix.python-version }}" quay.io/pypa/manylinux2014_aarch64 /io/bin/build_manylinux1_wheel.sh
+        docker run --platform linux/arm64 -v `pwd`:/io -e "PYTHON_VERSION=${{matrix.python-version}}" quay.io/pypa/manylinux2014_aarch64 /io/bin/build_manylinux1_wheel.sh
         mkdir test_wheel
         mv dist/emcache-*.whl test_wheel
     - name: Run unit tests using the wheel
       run: |
-        docker run --platform linux/arm64 --entrypoint bash -v `pwd`:/io python:3.11-bookworm /io/bin/test_aarch_wheel.sh
+        docker run --platform linux/arm64 --entrypoint bash -v `pwd`:/io python:${{matrix.python-version}}-bookworm /io/bin/test_aarch_wheel.sh
     - name: Get the version
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
@@ -157,9 +157,9 @@ jobs:
     - name: Display content
       run: ls -R
       working-directory: wheelhouse/
-    - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        packages_dir: wheelhouse/
-        password: ${{ secrets.PYPI_RELEASE_UPLOAD }}
-        repository_url: https://upload.pypi.org/legacy/
+    # - name: Publish distribution to PyPI
+    #   uses: pypa/gh-action-pypi-publish@master
+    #   with:
+    #     packages_dir: wheelhouse/
+    #     password: ${{ secrets.PYPI_RELEASE_UPLOAD }}
+    #     repository_url: https://upload.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,9 +157,9 @@ jobs:
     - name: Display content
       run: ls -R
       working-directory: wheelhouse/
-    # - name: Publish distribution to PyPI
-    #   uses: pypa/gh-action-pypi-publish@master
-    #   with:
-    #     packages_dir: wheelhouse/
-    #     password: ${{ secrets.PYPI_RELEASE_UPLOAD }}
-    #     repository_url: https://upload.pypi.org/legacy/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        packages_dir: wheelhouse/
+        password: ${{ secrets.PYPI_RELEASE_UPLOAD }}
+        repository_url: https://upload.pypi.org/legacy/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist
 *.c
 *.pyc
 *.swo
+venv

--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,12 @@ install: compile
 
 format:
 	isort --recursive .
-	black .
+	black --exclude=venv .
 
 lint:
 	isort --check-only --recursive .
-	black --check .
-	flake8
+	black --check --exclude=venv .
+	flake8 --exclude=venv .
 
 acceptance:
 	pytest -sv tests/acceptance

--- a/bin/build_manylinux1_wheel.sh
+++ b/bin/build_manylinux1_wheel.sh
@@ -32,6 +32,7 @@ cd /io/vendor/murmur3
 make static
 cd /io
 ${PYTHON} -m pip install --upgrade pip
+${PIP} install Cython
 ${PIP} install auditwheel
 PYTHON=${PYTHON} PIP=${PIP} CYTHON=${CYTHON} make compile
 ${PYTHON} setup.py bdist_wheel

--- a/bin/test_aarch_wheel.sh
+++ b/bin/test_aarch_wheel.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -eou
+cd /io
+
+cd vendor/murmur3
+make static
+cd /io
+
+pip install Cython
+make install-dev
+pip uninstall -y emcache
+
+pip install test_wheel/emcache-*.whl
+make unit


### PR DESCRIPTION
This change resolves issue https://github.com/emcache/emcache/issues/88.

Using the aarch build in https://github.com/acsylla/acsylla as a guide, with minor adjustments to be consistent with the build steps in emcache.

New github actions job added into release.yml, `build_linux_aarch64`. It builds the aarch64 wheel and then runs unit tests against the wheel. Acceptance tests are not being run because to test the wheel here we need to do it in docker; the acceptance tests would require a docker-in-docker scenario which I don't personally have the time to mess around with right now. I think we are ok with just unit tests for this job, as it's purpose is more of a sanity check against the build - the other jobs in the workflow are already running the full test suite so we get confidence in any code changes through them already.

I have verified that this new build job succeeds by running it in Github Actions on my fork (without the pypi upload step)