### PR TITLE
Updated is_key_valid() to match memcached

### DIFF
--- a/emcache/_cython/key_validation.pyx
+++ b/emcache/_cython/key_validation.pyx
@@ -6,13 +6,13 @@ def is_key_valid(bytes key) -> bool:
     From Memcache documentation, the key must not include control characters
     or whitespace, and must not take more than 250 characters.
     """
-    cdef int c
+    cdef unsigned char c
 
     if len(key) > MAX_KEY_LENGTH:
         return False
 
     for c in key:
-        if c < 33 or c > 126:
+        if c < 33 or c == 127:
             return False
 
     return True

--- a/tests/unit/_cython/test_key_validation.py
+++ b/tests/unit/_cython/test_key_validation.py
@@ -4,7 +4,7 @@ from emcache._cython import cyemcache
 
 
 class TestIsKeyValid:
-    @pytest.mark.parametrize("key", [b"foo", b"bar", b"foobar", b"foobarfoo", b"123foobarfoo123"])
+    @pytest.mark.parametrize("key", [b"foo", b"bar", b"foobar", b"foobarfoo", b"123foobarfoo123", "ñ".encode("utf8")])
     def test_valid_keys(self, key):
         assert cyemcache.is_key_valid(key) is True
 


### PR DESCRIPTION
This PR is another attempt to https://github.com/emcache/emcache/pull/89 and fixes https://github.com/emcache/emcache/issues/74

Please note that `"ñ".encode("utf16")` is not listed in unit tests as it translates to `\xff\xfe\xf1\x00` and `\x00` is not acceptable.