### PR TITLE
Fix race where in-use connection gets purged

### DIFF
--- a/emcache/connection_pool.py
+++ b/emcache/connection_pool.py
@@ -333,6 +333,7 @@ class ConnectionPool:
         while len(unused_connections) > 0:
             connection = unused_connections.pop()
             if connection.closed() is False:
+                self._connections_last_time_used[connection] = time.monotonic()
                 return ConnectionContext(self, connection, None)
 
             self._close_connection(connection)


### PR DESCRIPTION
`last_used_time` is only updated when a connection is released, which means that the following race can occur:

* `create_connection_context()` returns a connection which has expired (or is about to).
* Request is started on this connection.
* `_purge_unused_connections()` runs and purges the connection.
* Request fails.

Update `last_used_time` when an unused connection is acquired to fix this.