### PR TITLE
use new `docker compose` for engine version >=2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Docker dependencies
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
-        docker-compose up -d
+        docker compose up -d
         docker exec memcached_unix1 sh -c "chmod a+rw /tmp/emcache.test1.sock"
         docker exec memcached_unix2 sh -c "chmod a+rw /tmp/emcache.test2.sock"
     - name: Test


### PR DESCRIPTION
this style `docker-compose` is deprecated(compose engine v1)
use latest docker compose

https://docs.docker.com/compose/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2