### PR TITLE
use recommendation git clone `--recurse-submodules`  

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -155,7 +155,7 @@ Clone the repository and its murmur3 submodule
 
 .. code-block:: bash
 
-    git clone --recursive git@github.com:emcache/emcache
+    git clone --recurse-submodules git@github.com:emcache/emcache
 
 Compile murmur3
 


### PR DESCRIPTION
- use official option `--recurse-submodules` in git clone project and subprojects
- `--recurse` option was deprecated

official doc - https://git-scm.com/book/en/v2/Git-Tools-Submodules
diff - https://www.reddit.com/r/git/comments/f26qmf/difference_between_recursive_and_recursesubmodules/
forum - https://stackoverflow.com/questions/3796927/how-do-i-git-clone-a-repo-including-its-submodules
