### PR TITLE
drop deprecated xunit1 param pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,9 +12,6 @@ ignore = W503, E203
 [pep8]
 max-line-length = 120
 
-[tool:pytest]
-junit_family = xunit1
-
 [coverage:report]
 show_missing = true
 skip_covered = true


### PR DESCRIPTION
- drop deprecated xunit1, by default set xunit2
- link https://docs.pytest.org/en/latest/reference/reference.html#confval-junit_family