### PR TITLE
drop duplication run test, coverage already running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,6 @@ jobs:
         docker compose up -d
         docker exec memcached_unix1 sh -c "chmod a+rw /tmp/emcache.test1.sock"
         docker exec memcached_unix2 sh -c "chmod a+rw /tmp/emcache.test2.sock"
-    - name: Test
-      run: |
-        make test
     - name: Coverage
       run: |
         make coverage


### PR DESCRIPTION
make test is convenient for local development. However, with pipeline test coverage, it already runs unit tests. I think we test the code twice. Therefore, at the test coverage stage, you can already receive errors from tests and see code coverage.