### PR TITLE
Skip unix socket tests when running on Mac Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ acceptance:
 unit:
 	pytest -sv tests/unit
 
-test: 
+test:
 	pytest -sv tests
 
 coverage:

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -9,16 +9,13 @@ import pytest
 from emcache import MemcachedHostAddress, MemcachedUnixSocketPath, create_client
 
 NODE_ADDRESS_PARAMS = [
-    pytest.param(
-        [MemcachedHostAddress("localhost", 11211), MemcachedHostAddress("localhost", 11212)],
-        id="tcp_client"
-    )
+    pytest.param([MemcachedHostAddress("localhost", 11211), MemcachedHostAddress("localhost", 11212)], id="tcp_client")
 ]
 if sys.platform != "darwin":
     NODE_ADDRESS_PARAMS.append(
         pytest.param(
             [MemcachedUnixSocketPath("/tmp/emcache.test1.sock"), MemcachedUnixSocketPath("/tmp/emcache.test2.sock")],
-            id="unix_client"
+            id="unix_client",
         )
     )
 

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -1,24 +1,29 @@
 # MIT License
 # Copyright (c) 2020-2024 Pau Freixes
 
+import sys
 import time
 
 import pytest
 
 from emcache import MemcachedHostAddress, MemcachedUnixSocketPath, create_client
 
-
-@pytest.fixture(
-    params=[
-        pytest.param(
-            [MemcachedHostAddress("localhost", 11211), MemcachedHostAddress("localhost", 11212)], id="tcp_client"
-        ),
+NODE_ADDRESS_PARAMS = [
+    pytest.param(
+        [MemcachedHostAddress("localhost", 11211), MemcachedHostAddress("localhost", 11212)],
+        id="tcp_client"
+    )
+]
+if sys.platform != "darwin":
+    NODE_ADDRESS_PARAMS.append(
         pytest.param(
             [MemcachedUnixSocketPath("/tmp/emcache.test1.sock"), MemcachedUnixSocketPath("/tmp/emcache.test2.sock")],
-            id="unix_client",
-        ),
-    ]
-)
+            id="unix_client"
+        )
+    )
+
+
+@pytest.fixture(params=NODE_ADDRESS_PARAMS)
 def node_addresses(request):
     return request.param
 


### PR DESCRIPTION
Because Docker Desktop for Mac runs containers in a lightweight VM, bind‐mounting a Unix socket from a container to your host filesystem won't let you interact with it from macOS the way you normally would on a native Linux system.

Docker Desktop on macOS isolates container IPC (like Unix sockets) within the VM. The socket file is visible via the bind mount, but the actual IPC connection isn't exported to your macOS environment.

I believe the release to PyPi isn't happening because of its dependency on the test job passing. Resolving the tests should fix the upload to PyPi.

resolves #181