### PR TITLE
Another another upload fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,12 +162,16 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         path: wheelhouse/
+    - name: Move wheels to top-level wheelhouse directory
+      run: |
+        find wheelhouse/ -mindepth 2 -type f -name '*.whl' -exec mv {} wheelhouse/ \;
+        echo "Contents of wheelhouse after moving wheels:"
+        ls -R wheelhouse/
     - name: Display content
       run: ls -R
-      working-directory: wheelhouse/
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        packages-dir: wheelhouse/*/*.whl
+        packages-dir: wheelhouse/
         password: ${{ secrets.PYPI_RELEASE_UPLOAD }}
         repository-url: https://upload.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,10 +162,13 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         path: wheelhouse/
-    - name: Move wheels to top-level wheelhouse directory
+    - name: Clean up artifact directories in wheelhouse
       run: |
-        find wheelhouse/ -mindepth 2 -type f -name '*.whl' -exec mv {} wheelhouse/ \;
-        echo "Contents of wheelhouse after moving wheels:"
+        echo "Initial contents of wheelhouse:"
+        ls -R wheelhouse/
+        echo "Removing artifact subdirectories..."
+        find wheelhouse/ -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} \;
+        echo "Final contents of wheelhouse:"
         ls -R wheelhouse/
     - name: Display content
       run: ls -R

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,11 +169,10 @@ jobs:
         ls -R wheelhouse/
     - name: Clean up artifact directories in wheelhouse
       run: |
-        echo "Initial contents of wheelhouse:"
-        ls -R wheelhouse/
         echo "Removing artifact subdirectories..."
         find wheelhouse/ -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} \;
         echo "Final contents of wheelhouse:"
+        ls -R wheelhouse/
     - name: Display content
       run: ls -R
     - name: Publish distribution to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,10 +171,8 @@ jobs:
       run: |
         echo "Removing artifact subdirectories..."
         find wheelhouse/ -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} \;
-        echo "Final contents of wheelhouse:"
-        ls -R wheelhouse/
     - name: Display content
-      run: ls -R
+      run: ls -R wheelhouse/
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:


### PR DESCRIPTION
I think what pypa was most recently choking on was empty directories (currently required by the v4 version of the upload/download artifact flow) and this removes them before trying to publish.